### PR TITLE
Warnings removal for `-Wfloat-equal` and `-Wmissing-field-initializers`

### DIFF
--- a/extras/Build/CMake/JUCEHelperTargets.cmake
+++ b/extras/Build/CMake/JUCEHelperTargets.cmake
@@ -64,8 +64,8 @@ elseif((CMAKE_CXX_COMPILER_ID STREQUAL "Clang") OR (CMAKE_CXX_COMPILER_ID STREQU
         -Wswitch-enum
         -Wpedantic
         -Wdeprecated
-        -Wfloat-equal
-        -Wmissing-field-initializers
+        # -Wfloat-equal
+        # -Wmissing-field-initializers
         $<$<OR:$<COMPILE_LANGUAGE:CXX>,$<COMPILE_LANGUAGE:OBJCXX>>:
             -Wzero-as-null-pointer-constant
             -Wunused-private-field
@@ -94,8 +94,8 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         -Wredundant-decls
         -Wno-strict-overflow
         -Wshadow
-        -Wfloat-equal
-        -Wmissing-field-initializers
+        # -Wfloat-equal
+        # -Wmissing-field-initializers
         $<$<COMPILE_LANGUAGE:CXX>:
             -Woverloaded-virtual
             -Wreorder


### PR DESCRIPTION
Commented `-Wfloat-equal` and `-Wmissing-field-initializers` warnings in cmake.

