### PR TITLE
ValueTree::callListeners optimization

### DIFF
--- a/modules/juce_data_structures/values/juce_ValueTree.cpp
+++ b/modules/juce_data_structures/values/juce_ValueTree.cpp
@@ -81,8 +81,8 @@ public:
             {
                 auto* v = listenersCopy.getUnchecked (i);
 
-                if (i == 0 || valueTreesWithListeners.contains (v))
-                    v->listeners.callExcluding (listenerToExclude, fn);
+                if (i == 0 || valueTreesWithListeners[i] == v || valueTreesWithListeners.contains(v))
+                    v->listeners.callExcluding(listenerToExclude, fn);
             }
         }
     }


### PR DESCRIPTION
# Quick info
Optimization of `ValueTree::SharedObject::callListeners()`.

Check if the value tree pointer is still at the same index in `SortedSet` before calling `contains()` (search the whole `SortedSet`). 

This avoids most of the times (i.e. when `valueTreesWithListeners` is not modified by one the listeners) an expensive `contains(v)` call that runs in `O(log(n))`.

`valueTreesWithListeners[i]` is safe to call even if `i` is out of bound. In this case a `nullptr` is returned. (see `juce::SortedSet::operator[]` documentation).

# Performance improvements

It depends on the preset, but it goes from no impact to 2 times faster for full preset load. If we just look at the `_setPresetSection` function, it can be more than 3 times faster.

This was measured on the 10 first factory presets.

| **With Opt**            | **No Opt**            |
|------------------------|-----------------------|
| **Preset Load Time** ||
| 296.161 ms              | 287.215 ms             |
| 84.3419 ms              | 121.577 ms             |
| 107.104 ms              | 131.349 ms             |
| 109.48 ms               | 152.472 ms             |
| 212.962 ms              | 295.361 ms             |
| 130.955 ms              | 150.898 ms             |
| 163.667 ms              | 218.926 ms             |
| 219.574 ms              | 315.988 ms             |
| 110.971 ms              | 229.83 ms              |
| 97.6991 ms              | 178.813 ms             |
| **_setPresetSection**||
| 231.357 ms              | 267.21 ms              |
| 31.2568 ms              | 80.3071 ms             |
| 46.8507 ms              | 83.6666 ms             |
| 88.4895 ms              | 108.423 ms             |
| 195.72 ms               | 239.013 ms             |
| 49.6538 ms              | 119.618 ms             |
| 117.436 ms              | 166.917 ms             |
| 188.352 ms              | 257.056 ms             |
| 57.5271 ms              | 163.098 ms             |
| 31.8554 ms              | 117.022 ms             |
