### PR TITLE
fully disable D2D

### DIFF
--- a/modules/juce_graphics/images/juce_Image.cpp
+++ b/modules/juce_graphics/images/juce_Image.cpp
@@ -246,7 +246,7 @@ int NativeImageType::getTypeID() const
     return 1;
 }
 
-#if JUCE_LINUX || JUCE_BSD
+#if JUCE_LINUX || JUCE_BSD || JUCE_WINDOWS
 ImagePixelData::Ptr NativeImageType::create (Image::PixelFormat format, int width, int height, bool clearImage) const
 {
     return new SoftwarePixelData (format, width, height, clearImage);

--- a/modules/juce_graphics/native/juce_Direct2DImage_windows.cpp
+++ b/modules/juce_graphics/native/juce_Direct2DImage_windows.cpp
@@ -651,6 +651,7 @@ auto Direct2DPixelData::getPagesForContext (ComSmartPtr<ID2D1DeviceContext1> con
 }
 
 //==============================================================================
+/*
 ImagePixelData::Ptr NativeImageType::create (Image::PixelFormat format, int width, int height, bool clearImage) const
 {
     SharedResourcePointer<DirectX> directX;
@@ -667,6 +668,7 @@ ImagePixelData::Ptr NativeImageType::create (Image::PixelFormat format, int widt
 
     return new Direct2DPixelData (format, width, height, clearImage);
 }
+*/
 
 //==============================================================================
 //==============================================================================


### PR DESCRIPTION
See ENG-2371. Disable D2D as the native image context for `juce::Image`.