### PR TITLE
Disable Direct2D when calling Component::createNewPeer()

### DIFF
--- a/modules/juce_gui_basics/native/juce_Windowing_windows.cpp
+++ b/modules/juce_gui_basics/native/juce_Windowing_windows.cpp
@@ -4679,7 +4679,8 @@ ModifierKeys HWNDComponentPeer::modifiersAtLastCallback;
 
 ComponentPeer* Component::createNewPeer (int styleFlags, void* parentHWND)
 {
-    return new HWNDComponentPeer { *this, styleFlags, (HWND) parentHWND, false, 1 };
+    // Change the last argument (render engine) back to 1 to re-enable Direct2D - ENG-2487
+    return new HWNDComponentPeer { *this, styleFlags, (HWND) parentHWND, false, 0};
 }
 
 Image createSnapshotOfNativeWindow (void* nativeWindowHandle)


### PR DESCRIPTION
Changes the hardcoded render engine ID from Direct2D (1) to the software renderer (0).

This is part of our work to fully disable Direct2D but specifically addresses the issue outlines in [ENG-2487](https://linear.app/minimal-audio/issue/ENG-2487/slow-popupmenu-loading-windows).