### PR TITLE
Fix Identifier batch insertion

### DIFF
--- a/modules/juce_core/text/juce_Identifier.cpp
+++ b/modules/juce_core/text/juce_Identifier.cpp
@@ -74,9 +74,6 @@ Identifier::Identifier (const String& nm, bool alreadyInPool)
         name = StringPool::getGlobalPool().getPooledString (nm);
 
     jassert (name.getCharPointer() == nm.getCharPointer());
-
-    // Make sure the string is already in the pool
-    jassert (name.getCharPointer() == StringPool::getGlobalPool().getPooledString (name).getCharPointer());
 }
 
 Identifier::Identifier (const char* nm)

--- a/modules/juce_core/text/juce_Identifier.cpp
+++ b/modules/juce_core/text/juce_Identifier.cpp
@@ -61,21 +61,6 @@ Identifier::Identifier (const String& nm)
     jassert (nm.isNotEmpty());
 }
 
-Identifier::Identifier (const String& nm, bool alreadyInPool)
-: name (nm)
-{
-    // An Identifier cannot be created from an empty string!
-    jassert(nm.isNotEmpty());
-
-    jassertquiet(alreadyInPool);
-
-    // In case this constructor is used incorrectly
-    if (! alreadyInPool)
-        name = StringPool::getGlobalPool().getPooledString (nm);
-
-    jassert (name.getCharPointer() == nm.getCharPointer());
-}
-
 Identifier::Identifier (const char* nm)
     : name (StringPool::getGlobalPool().getPooledString (nm))
 {
@@ -96,6 +81,24 @@ bool Identifier::isValidIdentifier (const String& possibleIdentifier) noexcept
 {
     return possibleIdentifier.isNotEmpty()
             && possibleIdentifier.containsOnly ("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-:#@$%");
+}
+
+Identifier Identifier::getIdentifierFromInPoolString (const String& nm)
+{
+    Identifier id;
+
+    // An Identifier cannot be created from an empty string!
+    jassert (nm.isNotEmpty());
+
+    id.name = nm;
+
+    // Verify that both strings point to the same memory location
+    jassert (id.name.getCharPointer() == nm.getCharPointer());
+
+    // Verify that the string is actually in the pool (no side effects)
+    jassert (StringPool::getGlobalPool().isStringInPool (id.name));
+
+    return id;
 }
 
 } // namespace juce

--- a/modules/juce_core/text/juce_Identifier.h
+++ b/modules/juce_core/text/juce_Identifier.h
@@ -80,8 +80,6 @@ public:
     /** Creates a copy of another identifier. */
     Identifier (Identifier&& other) noexcept;
 
-    /** Creates identifier from a string already in the pool. */
-    Identifier (const String& nm, bool alreadyInPool);
 
     /** Creates a copy of another identifier. */
     Identifier& operator= (Identifier&& other) noexcept;
@@ -139,6 +137,13 @@ public:
         alphanumeric characters, underscores, or the '-' and ':' characters.
     */
     static bool isValidIdentifier (const String& possibleIdentifier) noexcept;
+
+    //==================== MA Additions Start =======================================
+    /** Creates an Identifier from a string that is already in the global string pool.
+        This is an optimization that avoids the pool lookup. The string must already be pooled.
+    */
+    static Identifier getIdentifierFromInPoolString (const String& inPoolString);
+    //==================== MA Additions End =========================================
 
 private:
     String name;

--- a/modules/juce_core/text/juce_StringPool.cpp
+++ b/modules/juce_core/text/juce_StringPool.cpp
@@ -173,6 +173,28 @@ StringPool& StringPool::getGlobalPool() noexcept
     return pool;
 }
 
+std::pair<bool, int> StringPool::locateOrGetInsertIndex (const String& newString, int startIndex, int endIndex) const
+{
+    int start = startIndex;
+    int end = endIndex;
+
+    while (start < end) {
+        const int halfway = (start + end) / 2;
+        const String& halfwayString = strings.getReference (halfway);
+        const int halfwayComp = compareStrings (newString, halfwayString);
+
+        if (halfwayComp == 0)
+            return { true, halfway };
+
+        if (halfwayComp > 0)
+            start = halfway + 1;
+        else
+            end = halfway;
+    }
+
+    return { false, start };
+}
+
 Array<Identifier> StringPool::addSortedStrings (const Array<String>& stringsToAdd)
 {
     // Assert that this is the global pool
@@ -208,7 +230,7 @@ Array<Identifier> StringPool::addSortedStrings (const Array<String>& stringsToAd
         auto [found, insertionIndex] = locateOrGetInsertIndex (startString, 0, strings.size());
 
         if (found) {
-            result.set (start, Identifier (strings.getReference (insertionIndex), true));
+            result.set (start, Identifier::getIdentifierFromInPoolString (strings.getReference (insertionIndex)));
             start++;
             continue;
         }
@@ -244,7 +266,7 @@ Array<Identifier> StringPool::addSortedStrings (const Array<String>& stringsToAd
         strings.insertArray (insertionIndex, stringsToAdd.begin() + start, numElems);
 
         for (int i = 0; i < numElems; i++)
-            result.set (i + start, Identifier (strings.getReference (insertionIndex + i), true));
+            result.set (i + start, Identifier::getIdentifierFromInPoolString (strings.getReference (insertionIndex + i)));
 
         start += numElems;
     }
@@ -260,26 +282,19 @@ Array<Identifier> StringPool::addSortedStrings (const Array<String>& stringsToAd
     return result;
 }
 
-std::pair<bool, int> StringPool::locateOrGetInsertIndex (const String& newString, int startIndex, int endIndex) const
+#if JUCE_DEBUG
+bool StringPool::isStringInPool (const String& str) const noexcept
 {
-    int start = startIndex;
-    int end = endIndex;
+    const ScopedLock sl (lock);
 
-    while (start < end) {
-        const int halfway = (start + end) / 2;
-        const String& halfwayString = strings.getReference (halfway);
-        const int halfwayComp = compareStrings (newString, halfwayString);
+    auto [found, index] = locateOrGetInsertIndex (str, 0, strings.size());
 
-        if (halfwayComp == 0)
-            return { true, halfway };
+    if (!found)
+        return false;
 
-        if (halfwayComp > 0)
-            start = halfway + 1;
-        else
-            end = halfway;
-    }
-
-    return { false, start };
+    // Verify that the character pointers actually match (same string instance)
+    return strings.getReference (index).getCharPointer() == str.getCharPointer();
 }
+#endif
 
 } // namespace juce

--- a/modules/juce_core/text/juce_StringPool.h
+++ b/modules/juce_core/text/juce_StringPool.h
@@ -88,17 +88,24 @@ public:
     /** Returns a shared global pool which is used for things like Identifiers, XML parsing. */
     static StringPool& getGlobalPool() noexcept;
 
-    //==============================================================================
-    /**
-     * Add a set of sorted strings to the pool and return an array of Identifiers that can be used to access them.
-     * The input array must be sorted and contain no duplicates.
-     */
+    //==================== MA Additions Start =======================================
+    /** Add a set of sorted strings to the pool and return an array of Identifiers that can be used to access them.
+        The input array must be sorted and contain no duplicates.
+    */
     Array<Identifier> addSortedStrings (const Array<String>& stringsToAdd);
+
+#if JUCE_DEBUG
+    /** Check if a string is **in** the pool by comparing character pointers (debug only, no side effects).
+        It does not check if an equivalent string is in the pool, only if **this** instance of the string is in the pool.
+    */
+    bool isStringInPool (const String& str) const noexcept;
+#endif
 
 #if MA_UNIT_TESTS
     /** Returns the underlying array of strings. */
     const Array<String>& getStrings() const noexcept { return strings; }
 #endif
+    //==================== MA Additions End =========================================
 
 private:
 


### PR DESCRIPTION
Removed a `jassert` that could internally call garbage collection on the StringPool, while the reference counts of the newly added strings were 1 (triggerring deletions).

The garbage collection happened just before the Identifiers referring to the added string were created, increasing the ref count to 2 (preventing garbage collection).

Now: 
- Clearer indication of MA additions to JUCE
- Named factory to create in pool string instead of constructor
- Check that we get an in pool string efficiently with no side effects
