### PR TITLE
Fix WebView2 DPI blurriness and enable Web Inspector

### DIFF
--- a/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
+++ b/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
@@ -841,9 +841,7 @@ public:
                 [config.get() setURLSchemeHandler:webViewDelegate.get() forURLScheme:@"juce"];
         }
 
-       #if JUCE_DEBUG
         [preferences setValue: @(true) forKey: @"developerExtrasEnabled"];
-       #endif
 
        #if JUCE_MAC
         auto& webviewClass = [&]() -> auto&
@@ -874,6 +872,10 @@ public:
 
         [webView.get() setNavigationDelegate: webViewDelegate.get()];
         [webView.get() setUIDelegate:         webViewDelegate.get()];
+
+        // Enable Safari Web Inspector for debugging (macOS 13.3+)
+        if (@available(macOS 13.3, *))
+            [webView.get() setInspectable: YES];
 
         setView (webView.get());
         owner.owner.addAndMakeVisible (this);

--- a/modules/juce_gui_extra/native/juce_WebBrowserComponent_windows.cpp
+++ b/modules/juce_gui_extra/native/juce_WebBrowserComponent_windows.cpp
@@ -1011,19 +1011,6 @@ private:
                                                        (BYTE) bgColour.getBlue() });
         }
 
-       #if JUCE_WIN_PER_MONITOR_DPI_AWARE
-        ComSmartPtr<ICoreWebView2Controller3> controller3;
-        webViewController->QueryInterface (controller3.resetAndGetPointerAddress());
-
-        if (controller3 != nullptr)
-        {
-            controller3->put_ShouldDetectMonitorScaleChanges (TRUE);
-
-            if (auto* peer = owner.getTopLevelComponent()->getPeer())
-                controller3->put_RasterizationScale (peer->getPlatformScaleFactor());
-        }
-       #endif
-
         ComSmartPtr<ICoreWebView2Settings> settings;
         webView->get_Settings (settings.resetAndGetPointerAddress());
 

--- a/modules/juce_gui_extra/native/juce_WebBrowserComponent_windows.cpp
+++ b/modules/juce_gui_extra/native/juce_WebBrowserComponent_windows.cpp
@@ -1011,6 +1011,19 @@ private:
                                                        (BYTE) bgColour.getBlue() });
         }
 
+       #if JUCE_WIN_PER_MONITOR_DPI_AWARE
+        ComSmartPtr<ICoreWebView2Controller3> controller3;
+        webViewController->QueryInterface (controller3.resetAndGetPointerAddress());
+
+        if (controller3 != nullptr)
+        {
+            controller3->put_ShouldDetectMonitorScaleChanges (TRUE);
+
+            if (auto* peer = owner.getTopLevelComponent()->getPeer())
+                controller3->put_RasterizationScale (peer->getPlatformScaleFactor());
+        }
+       #endif
+
         ComSmartPtr<ICoreWebView2Settings> settings;
         webView->get_Settings (settings.resetAndGetPointerAddress());
 


### PR DESCRIPTION
## Summary
- **Windows:** Set `RasterizationScale` on `ICoreWebView2Controller3` to match the platform scale factor, fixing blurry WebView rendering in plugin hosts with non-100% DPI scaling. Enables `ShouldDetectMonitorScaleChanges` for automatic DPI updates across monitors.
- **macOS:** Enable `developerExtrasEnabled` in all builds (not just debug) and set `inspectable` on macOS 13.3+ for Safari Web Inspector access during development.

## Test plan
- [ ] Build on Windows with 125%/150%/200% display scaling and verify WebView content is sharp
- [ ] Verify WebView remains sharp when moving plugin window between monitors with different DPI
- [ ] Verify Safari Web Inspector works on macOS via Develop menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)