### PR TITLE
WebView: release-build inspector + cross-platform background-colour Options API

### DIFF
--- a/modules/juce_gui_extra/misc/juce_WebBrowserComponent.h
+++ b/modules/juce_gui_extra/misc/juce_WebBrowserComponent.h
@@ -259,12 +259,35 @@ public:
                 return withMember (*this, &AppleWkWebView::acceptsFirstMouse, false);
             }
 
+            /** Sets the background colour that the WKWebView paints underneath all web content.
+
+                By default WKWebView's NSView paints an opaque white background until the page
+                actually renders, which causes a one-frame flash whenever the surface is shown
+                or resized into real bounds. Setting a colour here turns that off so the JUCE
+                layer beneath composites through (transparent / clear colour), or the chosen
+                colour shows in the overscroll area (macOS 12+ / iOS 15+).
+
+                This mirrors the equivalent option on WinWebView2 so cross-platform host code
+                can configure both backends from one place.
+
+                The colour must be either fully opaque or fully transparent.
+            */
+            [[nodiscard]] AppleWkWebView withBackgroundColour (const Colour& colour) const
+            {
+                // the background colour must be either fully opaque or transparent!
+                jassert (colour.isOpaque() || colour.isTransparent());
+
+                return withMember (*this, &AppleWkWebView::backgroundColour, colour);
+            }
+
             auto getAllowAccessToEnclosingDirectory() const { return allowAccessToEnclosingDirectory; }
-            auto getAcceptsFirstMouse() const { return acceptsFirstMouse; }
+            auto getAcceptsFirstMouse() const                { return acceptsFirstMouse; }
+            auto getBackgroundColour() const                 { return backgroundColour; }
 
         private:
             bool allowAccessToEnclosingDirectory = false;
             bool acceptsFirstMouse = true;
+            std::optional<Colour> backgroundColour;
         };
 
         /** Specifies options that apply to the Windows implementation when the WebView2 feature is

--- a/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
+++ b/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
@@ -926,15 +926,18 @@ public:
         // painted: drawsBackground = NO makes the OS surface transparent so
         // the JUCE layer beneath composites through, and (on macOS 12+ /
         // iOS 15+) the public setUnderPageBackgroundColor handles the
-        // overscroll bounce area. Set on `config` rather than the webview
-        // so the property is in place before the first paint. KVC on
-        // `drawsBackground` is documented private but stable since 10.14 —
-        // this is the same approach Tauri/wry uses (`wry/src/wkwebview/mod.rs`).
+        // overscroll bounce area.
+        //
+        // The KVC trick must target the WKWebView itself, not the
+        // WKWebViewConfiguration — WKWebView copies config values at init
+        // time, so setValue on config after webview creation is a no-op.
+        // `drawsBackground` is undocumented but stable since macOS 10.14
+        // and is what Safari, Xcode and Tauri/wry use.
         if (const auto bg = browserOptions.getAppleWkWebViewOptions().getBackgroundColour())
         {
             @try
             {
-                [config.get() setValue: @(NO) forKey: @"drawsBackground"];
+                [webView.get() setValue: @(NO) forKey: @"drawsBackground"];
             }
             @catch (NSException* exception)
             {
@@ -942,6 +945,18 @@ public:
                 // fall back silently rather than crashing the host.
                 (void) exception;
             }
+
+           #if JUCE_MAC
+            // Belt-and-braces: also tell the underlying NSView's CALayer
+            // not to paint its own opaque background. Some WebKit builds
+            // still flash on the very first frame because the host NSView
+            // composites independently of the WKWebView's drawsBackground.
+            // Setting wantsLayer + a transparent layer background is a
+            // public-API safety net.
+            [webView.get() setWantsLayer: YES];
+            if (auto* layer = [webView.get() layer])
+                layer.backgroundColor = CGColorGetConstantColor (kCGColorClear);
+           #endif
 
             if (@available (macOS 12.0, iOS 15.0, *))
             {

--- a/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
+++ b/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
@@ -921,6 +921,46 @@ public:
         if (@available (macOS 13.3, iOS 16.4, *))
             [webView.get() setInspectable: YES];
 
+        // Mirrors WinWebView2::withBackgroundColour. Stops WKWebView from
+        // flashing its default opaque background colour before the page has
+        // painted: drawsBackground = NO makes the OS surface transparent so
+        // the JUCE layer beneath composites through, and (on macOS 12+ /
+        // iOS 15+) the public setUnderPageBackgroundColor handles the
+        // overscroll bounce area. Set on `config` rather than the webview
+        // so the property is in place before the first paint. KVC on
+        // `drawsBackground` is documented private but stable since 10.14 —
+        // this is the same approach Tauri/wry uses (`wry/src/wkwebview/mod.rs`).
+        if (const auto bg = browserOptions.getAppleWkWebViewOptions().getBackgroundColour())
+        {
+            @try
+            {
+                [config.get() setValue: @(NO) forKey: @"drawsBackground"];
+            }
+            @catch (NSException* exception)
+            {
+                // KVC compliance is private API; if a future OS rejects it,
+                // fall back silently rather than crashing the host.
+                (void) exception;
+            }
+
+            if (@available (macOS 12.0, iOS 15.0, *))
+            {
+                const auto c = *bg;
+               #if JUCE_MAC
+                auto* colour = [NSColor colorWithSRGBRed: c.getFloatRed()
+                                                   green: c.getFloatGreen()
+                                                    blue: c.getFloatBlue()
+                                                   alpha: c.getFloatAlpha()];
+               #else
+                auto* colour = [UIColor colorWithRed: c.getFloatRed()
+                                               green: c.getFloatGreen()
+                                                blue: c.getFloatBlue()
+                                               alpha: c.getFloatAlpha()];
+               #endif
+                [webView.get() setUnderPageBackgroundColor: colour];
+            }
+        }
+
         setView (webView.get());
         owner.owner.addAndMakeVisible (this);
     }

--- a/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
+++ b/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
@@ -878,9 +878,11 @@ public:
                 [config.get() setURLSchemeHandler:webViewDelegate.get() forURLScheme:@"juce"];
         }
 
-       #if JUCE_DEBUG
+        // Enable the Safari Web Inspector in all build configurations.
+        // Plugins running inside a DAW are inherently a release-build target,
+        // so gating this on JUCE_DEBUG made the inspector unreachable in the
+        // only environment where developers actually run them.
         [preferences setValue: @(true) forKey: @"developerExtrasEnabled"];
-       #endif
 
        #if JUCE_MAC
         auto& webviewClass = [&]() -> auto&
@@ -911,6 +913,13 @@ public:
 
         [webView.get() setNavigationDelegate: webViewDelegate.get()];
         [webView.get() setUIDelegate:         webViewDelegate.get()];
+
+        // The `developerExtrasEnabled` preference above is the legacy path
+        // and remains sufficient on older macOS. From 13.3 / iOS 16.4 onward
+        // Apple requires the public `inspectable` property to be set as well
+        // before Safari's Develop menu will list this WebView.
+        if (@available (macOS 13.3, iOS 16.4, *))
+            [webView.get() setInspectable: YES];
 
         setView (webView.get());
         owner.owner.addAndMakeVisible (this);

--- a/modules/juce_gui_extra/native/juce_WebBrowserComponent_windows.cpp
+++ b/modules/juce_gui_extra/native/juce_WebBrowserComponent_windows.cpp
@@ -1019,9 +1019,11 @@ private:
 
         if (settings != nullptr)
         {
-           #if ! JUCE_DEBUG
-            settings->put_AreDevToolsEnabled (false);
-           #endif
+            // Leave WebView2 DevTools enabled in all build configurations.
+            // Plugins running inside a DAW are inherently a release-build
+            // target, so disabling DevTools in release made the inspector
+            // unreachable in the only environment where developers
+            // actually run them.
 
             settings->put_IsStatusBarEnabled (! preferences.getWinWebView2BackendOptions().getIsStatusBarDisabled());
             settings->put_IsBuiltInErrorPageEnabled (! preferences.getWinWebView2BackendOptions().getIsBuiltInErrorPageDisabled());


### PR DESCRIPTION
## Summary

1. **Inspector access in release builds** (`c93b9139ed`)
   - macOS: drop `JUCE_DEBUG` guard around `developerExtrasEnabled`, add `setInspectable: YES` for macOS 13.3+ / iOS 16.4+.
   - Windows: drop the `#if !JUCE_DEBUG put_AreDevToolsEnabled(false)` block.
   - Re-applies 7330a68e03, which was dropped by the 58c87ee063 develop merge.

2. **Cross-platform pre-paint background-colour control** (`bdddb1619c`)
   - Adds `WebBrowserComponent::Options::AppleWkWebView::withBackgroundColour(Colour)` mirroring the existing `WinWebView2::withBackgroundColour`. When set, macOS uses `drawsBackground = NO` via KVC (same private-but-stable trick Tauri/wry uses) and, on macOS 12+, the public `setUnderPageBackgroundColor`. Opt-in — default behaviour unchanged.
   - Windows already supports this via `WinWebView2::withBackgroundColour`. No code change needed there.
   - Linux (webkit2gtk) does not yet expose `webkit_web_view_set_background_color` through JUCE's symbol resolver — flagged as a follow-up in the commit message.

## Why

Plugins ship as release builds and run inside a DAW host — `JUCE_DEBUG`-only gating made the inspector unreachable in the only environment plugin UIs actually run in.

WKWebView paints an opaque default background (white in light mode, a system grey in dark mode) until the first content frame renders. Plugins that gate webview visibility on a first-paint handshake (1×1 during boot, hidden-then-shown, etc.) see this flash every launch. The `drawsBackground` KVC trick lets the host paint its own background through the transparent surface — the same approach Tauri/wry takes across all three platforms.

## Test plan

- [ ] macOS: build a Release plugin with `juce::WebBrowserComponent`. Attach Safari → Develop → [Mac] → [WebView entry]; inspector connects.
- [ ] macOS: with `Options::AppleWkWebView{}.withBackgroundColour(Colour(0,0,0,0))` set on a webview that gates visibility on a first-paint handshake, confirm no flash on first reveal.
- [ ] macOS without `withBackgroundColour`: confirm behaviour is unchanged from upstream.
- [ ] iOS: smoke-test that `withBackgroundColour` doesn't break a release build.
- [ ] Windows: existing `WinWebView2::withBackgroundColour` continues to work; Release inspector still right-click → Inspect.