### PR TITLE
WebView (Windows): fix startup flicker via --default-background-color

### DIFF
--- a/modules/juce_gui_extra/native/juce_WebBrowserComponent_windows.cpp
+++ b/modules/juce_gui_extra/native/juce_WebBrowserComponent_windows.cpp
@@ -668,6 +668,26 @@ public:
 
         auto webViewOptions = Microsoft::WRL::Make<CoreWebView2EnvironmentOptions>();
 
+        // Mirror AppleWkWebView's drawsBackground = NO trick on Windows by
+        // pre-seeding the chromium renderer's default background colour via
+        // the command line. WebView2's runtime-level put_DefaultBackgroundColor
+        // is applied in setWebViewPreferences() *after* the controller is
+        // created, leaving a small window in which the renderer can paint its
+        // default opaque-white frame before our colour takes effect. Setting
+        // the chromium --default-background-color switch on the environment's
+        // additional browser arguments threads the colour through to the
+        // renderer process at launch, so the very first paint already uses it.
+        // Hex format matches chromium's content_switches parser
+        // (#AARRGGBB or AARRGGBB, both accepted).
+        const auto bgColour = options.getWinWebView2BackendOptions().getBackgroundColour();
+        const auto bgArg = String::formatted ("--default-background-color=#%02X%02X%02X%02X",
+                                              bgColour.getAlpha(),
+                                              bgColour.getRed(),
+                                              bgColour.getGreen(),
+                                              bgColour.getBlue());
+
+        webViewOptions->put_AdditionalBrowserArguments (bgArg.toWideCharPointer());
+
         const auto userDataFolder = options.getWinWebView2BackendOptions().getUserDataFolder().getFullPathName();
 
         auto hr = createWebViewEnvironmentWithOptions (nullptr,


### PR DESCRIPTION
## Summary

Plugins that gate webview visibility on a first-paint handshake see a white flash on first reveal *on Windows*. PR #24 fixed the equivalent flicker on macOS via WKWebView's \`drawsBackground = NO\` KVC trick; this PR fixes the Windows side.

The existing \`put_DefaultBackgroundColor\` call in \`setWebViewPreferences()\` runs **after** the controller is created. By that point the renderer process can already have painted its default opaque-white frame. This patch passes the configured \`WinWebView2::backgroundColour\` through to the chromium renderer at process-launch time via \`--default-background-color\` in \`ICoreWebView2EnvironmentOptions::AdditionalBrowserArguments\`, so the first paint already uses the host colour.

## Why this works

\`AdditionalBrowserArguments\` is applied when WebView2 spawns its renderer process. The chromium \`--default-background-color\` switch is read at renderer init, before any web content is loaded, before any frame is painted. Tauri/wry use the same approach for the same reason.

The existing post-creation \`put_DefaultBackgroundColor\` call stays — it covers later paints (navigation between origins, new contexts, etc.) and isn't redundant.

## Test plan

- [ ] Windows: build a Release plugin with \`Options::WinWebView2{}.withBackgroundColour(host_bg)\` on a webview that gates visibility on a first-paint handshake. Confirm no white flash on first reveal.
- [ ] Windows without \`withBackgroundColour\`: behaviour unchanged from upstream (the default \`Colour()\` is transparent black, which is what the current post-creation call already requests).
- [ ] Linux: untouched.
- [ ] macOS: untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)