### PR TITLE
WebView (Windows): use ICoreWebView2ControllerOptions4 for AllowHostInputProcessing

### DIFF
--- a/modules/juce_gui_extra/native/juce_WebBrowserComponent_windows.cpp
+++ b/modules/juce_gui_extra/native/juce_WebBrowserComponent_windows.cpp
@@ -995,7 +995,7 @@ private:
             // has reported editable DOM focus we set put_Handled(TRUE) so the
             // WebView keeps the key for in-DOM editing (e.g. Tab to indent,
             // Esc to dismiss a popover). This complements
-            // ICoreWebView2ControllerOptions2::AllowHostInputProcessing, which
+            // ICoreWebView2ControllerOptions4::AllowHostInputProcessing, which
             // covers the character keys (spacebar, QWERTY) that
             // AcceleratorKeyPressed does not fire for.
             webViewController->add_AcceleratorKeyPressed (
@@ -1213,13 +1213,13 @@ private:
                     return E_NOINTERFACE;
                 }
 
-                ComSmartPtr<ICoreWebView2ControllerOptions2> controllerOptions2;
-                controllerOptions.QueryInterface (controllerOptions2);
+                ComSmartPtr<ICoreWebView2ControllerOptions4> controllerOptions4;
+                controllerOptions.QueryInterface (controllerOptions4);
 
-                if (controllerOptions2 == nullptr)
+                if (controllerOptions4 == nullptr)
                     return E_NOINTERFACE;
 
-                if (controllerOptions2->put_AllowHostInputProcessing (TRUE) != S_OK)
+                if (controllerOptions4->put_AllowHostInputProcessing (TRUE) != S_OK)
                     return E_FAIL;
 
                 return environment10->CreateCoreWebView2ControllerWithOptions (hostHwnd,


### PR DESCRIPTION
## Summary
- Fixes the Windows Player build that has been broken since PR #25 (the keyboard-passthrough patch).
- The code was querying `ICoreWebView2ControllerOptions2`, which only exposes `ScriptLocale`. `put_AllowHostInputProcessing` lives on `ICoreWebView2ControllerOptions4` (introduced in WebView2 Win32 SDK 1.0.3351.48 — well below our CI-pinned 1.0.3485.44).

## Why CI didn't catch this
PRs #25 and #26 didn't run the Release Player workflow that builds Windows; the failure first surfaced when `Release Player` was dispatched against `main` (https://github.com/Minimal-Audio/minimal_core/actions/runs/26317655858/job/77480189355).

## Build error before fix
\`\`\`
juce_WebBrowserComponent_windows.cpp:1222:41:
error: no member named 'put_AllowHostInputProcessing' in 'ICoreWebView2ControllerOptions2'
\`\`\`

## Test plan
- [ ] minimal_core Release Player workflow Windows build succeeds with submodule pinned to this branch tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)