### PR TITLE
WebView (Windows): drop AllowHostInputProcessing + AcceleratorKeyPressed

### DIFF
--- a/modules/juce_gui_extra/native/juce_WebBrowserComponent_windows.cpp
+++ b/modules/juce_gui_extra/native/juce_WebBrowserComponent_windows.cpp
@@ -517,11 +517,6 @@ public:
             webViewController->MoveFocus (moveFocusReason);
     }
 
-    void setEditableFocusActive (bool active) override
-    {
-        editableFocusActive.store (active, std::memory_order_relaxed);
-    }
-
     ~WebView2() override
     {
         if (webView2ConstructionHelper.webView2BeingCreated == this)
@@ -983,27 +978,6 @@ private:
 
                     return S_OK;
                 }).Get(), &moveFocusRequestedToken);
-
-            // AcceleratorKeyPressed fires for accelerator keys (Tab, Esc,
-            // F-keys, modifier combos) before WebView2 processes them. Marking
-            // put_Handled(FALSE) yields the key to the host's window proc so
-            // the plugin host (DAW) receives Cmd/Ctrl shortcuts and transport
-            // controls — the default behaviour users expect. When the JS layer
-            // has reported editable DOM focus we set put_Handled(TRUE) so the
-            // WebView keeps the key for in-DOM editing (e.g. Tab to indent,
-            // Esc to dismiss a popover). This complements
-            // ICoreWebView2ControllerOptions4::AllowHostInputProcessing, which
-            // covers the character keys (spacebar, QWERTY) that
-            // AcceleratorKeyPressed does not fire for.
-            webViewController->add_AcceleratorKeyPressed (
-                Callback<ICoreWebView2AcceleratorKeyPressedEventHandler> (
-                    [this] (ICoreWebView2Controller*, ICoreWebView2AcceleratorKeyPressedEventArgs* args) -> HRESULT
-                    {
-                        if (args != nullptr)
-                            args->put_Handled (editableFocusActive.load (std::memory_order_relaxed) ? TRUE : FALSE);
-
-                        return S_OK;
-                    }).Get(), &acceleratorKeyPressedToken);
         }
     }
 
@@ -1037,9 +1011,6 @@ private:
         {
             if (moveFocusRequestedToken.value != 0)
                 webViewController->remove_MoveFocusRequested (moveFocusRequestedToken);
-
-            if (acceleratorKeyPressedToken.value != 0)
-                webViewController->remove_AcceleratorKeyPressed (acceleratorKeyPressedToken);
         }
     }
 
@@ -1203,47 +1174,7 @@ private:
                         return S_OK;
                     });
 
-            // Prefer CreateCoreWebView2ControllerWithOptions so we can enable
-            // AllowHostInputProcessing — that routes keyboard/mouse input
-            // through the host's window proc, letting the plugin host (DAW)
-            // see character keys (spacebar, QWERTY) that WebView2 would
-            // otherwise consume entirely. AcceleratorKeyPressed handles the
-            // accelerator-key subset for runtimes/SDKs that don't expose the
-            // option. Falling back to the plain Create function keeps the
-            // backend working when either the environment (older runtime) or
-            // the controller options (older SDK) interface is unavailable.
-            const auto createWithHostInputProcessing = [&]() -> HRESULT
-            {
-                ComSmartPtr<ICoreWebView2Environment10> environment10;
-                webViewHandle.environment.QueryInterface (environment10);
-
-                if (environment10 == nullptr)
-                    return E_NOINTERFACE;
-
-                ComSmartPtr<ICoreWebView2ControllerOptions> controllerOptions;
-
-                if (environment10->CreateCoreWebView2ControllerOptions (controllerOptions.resetAndGetPointerAddress()) != S_OK
-                    || controllerOptions == nullptr)
-                {
-                    return E_NOINTERFACE;
-                }
-
-                ComSmartPtr<ICoreWebView2ControllerOptions4> controllerOptions4;
-                controllerOptions.QueryInterface (controllerOptions4);
-
-                if (controllerOptions4 == nullptr)
-                    return E_NOINTERFACE;
-
-                if (controllerOptions4->put_AllowHostInputProcessing (TRUE) != S_OK)
-                    return E_FAIL;
-
-                return environment10->CreateCoreWebView2ControllerWithOptions (hostHwnd,
-                                                                               controllerOptions.get(),
-                                                                               completionHandler.Get());
-            }();
-
-            if (! SUCCEEDED (createWithHostInputProcessing))
-                webViewHandle.environment->CreateCoreWebView2Controller (hostHwnd, completionHandler.Get());
+            webViewHandle.environment->CreateCoreWebView2Controller (hostHwnd, completionHandler.Get());
         }
     }
 
@@ -1318,16 +1249,9 @@ private:
                            navigationCompletedToken   { 0 },
                            webResourceRequestedToken  { 0 },
                            moveFocusRequestedToken    { 0 },
-                           webMessageReceivedToken    { 0 },
-                           acceleratorKeyPressedToken { 0 };
+                           webMessageReceivedToken    { 0 };
 
     bool inMoveFocusRequested = false;
-
-    // Default false → AcceleratorKeyPressed releases keys to the host's window
-    // proc so the DAW receives shortcuts. Flipped to true by the JS layer via
-    // __juceSetEditableFocusActive whenever an editable DOM element gains
-    // focus, so the WebView retains keys for in-DOM editing.
-    std::atomic<bool> editableFocusActive { false };
 
     struct URLRequest
     {


### PR DESCRIPTION
## Summary

The host-input-processing route never actually got transport keys (Space, QWERTY) to the DAW: `AllowHostInputProcessing` only forwards `WM_KEYDOWN` to the WebView2's host HWND — which is JUCE's browser-host child window, not the DAW's plugin frame. JUCE's window proc dispatches to the focused JUCE component, not back up the HWND chain, so the key dies locally and never reaches the DAW.

Switching consumers in `minimal_core` to a JS-side triage that explicitly `PostMessage`s host-bound keys into the JUCE peer's HWND via a bridge capability, which routes through JUCE's standard key dispatch correctly. The Windows-side `AllowHostInputProcessing` + `AcceleratorKeyPressed` wiring is dead weight for that flow.

## What changes

- Reverts the Windows half of #26 (`WebView: forward keys to host responder chain by default`) — removes the `AcceleratorKeyPressed` subscription, the `editableFocusActive` atomic on the Windows backend, and the `setEditableFocusActive` override
- Reverts all of #27 (`WebView (Windows): query ICoreWebView2ControllerOptions4 for AllowHostInputProcessing`) — removes the `CreateCoreWebView2ControllerWithOptions` path and goes back to the plain `CreateCoreWebView2Controller`

The macOS responder-chain forwarding (`WebBrowserComponent_mac.mm`) stays — that path works correctly and the new JS triage no-ops there. `setEditableFocusActive` remains in the public `WebBrowserComponent` API and on the macOS backend; only the Windows override (which became dead weight) goes.

## Test plan

- [ ] Verify the plugin form still loads and the WebView2 renders normally
- [ ] Verify keyboard works in DOM inputs (typing into preset search etc.)
- [ ] In `minimal_core`'s consumer-side PR: verify transport keys (Space) reach the DAW via the new JS triage path

🤖 Generated with [Claude Code](https://claude.com/claude-code)