### PR TITLE
WebView: drop setEditableFocusActive + responder-chain forwarding

### DIFF
--- a/modules/juce_gui_extra/misc/juce_WebBrowserComponent.cpp
+++ b/modules/juce_gui_extra/misc/juce_WebBrowserComponent.cpp
@@ -378,30 +378,10 @@ private:
 class WebBrowserComponent::Impl
 {
 public:
-    Impl (WebBrowserComponent& ownerIn, const Options& optionsInRaw)
+    Impl (WebBrowserComponent& ownerIn, const Options& optionsIn)
         : owner (ownerIn),
           options ([&]
                    {
-                       // Auto-register a native function so JS can flip the editable-focus
-                       // routing without every consumer wiring up their own bridge plumbing.
-                       // Only registered when native integration is already in use — adding
-                       // it unconditionally would force `withNativeIntegrationEnabled` on for
-                       // every WebBrowserComponent, which JUCE flags as a security risk for
-                       // components loading untrusted content.
-                       const bool nativeIntegrationInUse = optionsInRaw.getNativeIntegrationsEnabled()
-                                                          || ! optionsInRaw.getNativeFunctions().empty();
-
-                       const auto optionsIn = nativeIntegrationInUse
-                           ? optionsInRaw.withNativeFunction (
-                                 "__juceSetEditableFocusActive",
-                                 [this] (const Array<var>& args, const std::function<void (var)>& completion)
-                                 {
-                                     if (! args.isEmpty())
-                                         setEditableFocusActive (static_cast<bool> (args[0]));
-                                     completion ({});
-                                 })
-                           : optionsInRaw;
-
                        makeFunctionsProviderIfNecessary (nativeFunctionsProvider, *this, optionsIn);
 
                        if (nativeFunctionsProvider.has_value())
@@ -503,11 +483,6 @@ public:
         platform->focusGainedWithDirection (type, dir);
     }
 
-    void setEditableFocusActive (bool active)
-    {
-        platform->setEditableFocusActive (active);
-    }
-
     struct Platform;
 
 private:
@@ -529,12 +504,6 @@ private:
         virtual void focusGainedWithDirection (FocusChangeType, FocusChangeDirection) {}
         virtual void fallbackPaint (Graphics&) {}
 
-        // Default no-op — platforms that support host keyboard pass-through
-        // (macOS WKWebView, Windows WebView2) override this to flip the
-        // routing of OS-level key events between the host responder chain
-        // and the embedded DOM. See WebBrowserComponent::setEditableFocusActive
-        // for the semantics.
-        virtual void setEditableFocusActive (bool) {}
     };
 
     static void makeFunctionsProviderIfNecessary (std::optional<NativeFunctionsProvider>& provider,
@@ -754,11 +723,6 @@ void WebBrowserComponent::focusGainedWithDirection (FocusChangeType type,
                                                     FocusChangeDirection direction)
 {
     impl->focusGainedWithDirection (type, direction);
-}
-
-void WebBrowserComponent::setEditableFocusActive (bool editableFocusActive)
-{
-    impl->setEditableFocusActive (editableFocusActive);
 }
 
 #endif

--- a/modules/juce_gui_extra/misc/juce_WebBrowserComponent.h
+++ b/modules/juce_gui_extra/misc/juce_WebBrowserComponent.h
@@ -609,36 +609,6 @@ public:
     */
     void emitEventIfBrowserIsVisible (const Identifier& eventId, const var& object);
 
-    /** Controls whether key events received by the underlying OS web surface should be
-        forwarded to the host responder chain instead of being consumed by the web view.
-
-        When the WebBrowserComponent is hosted inside a plugin, the OS web surface
-        (WKWebView on macOS, WebView2 on Windows) becomes first responder on click and
-        swallows keystrokes — preventing host shortcuts (transport, MIDI typing keyboards,
-        etc.) from reaching the DAW. JUCE's default behaviour is to forward those keys
-        to the host so the DAW remains controllable. Call this with `true` while an
-        editable DOM element (e.g. an `<input>`) has focus so character input reaches
-        the DOM, and `false` again when the editable element loses focus.
-
-        Frontend code can drive this through the auto-registered native function
-        `__juceSetEditableFocusActive`, available via JUCE's `getNativeFunction` helper:
-
-        @code
-        import { getNativeFunction } from 'juce-framework-frontend';
-        const setEditableFocus = getNativeFunction('__juceSetEditableFocusActive');
-        document.addEventListener('focusin', e => {
-            const t = e.target;
-            const editable =
-                t instanceof HTMLInputElement ||
-                t instanceof HTMLTextAreaElement ||
-                t instanceof HTMLSelectElement ||
-                (t instanceof HTMLElement && t.isContentEditable);
-            setEditableFocus(editable);
-        });
-        @endcode
-    */
-    void setEditableFocusActive (bool editableFocusActive);
-
     //==============================================================================
     /** This callback is called when the browser is about to navigate
         to a new location.

--- a/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
+++ b/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
@@ -176,22 +176,6 @@ static const char* lastFocusChangeMemberName = "lastFocusChangeHandle";
     return getIvar<LastFocusChange*> (instance, lastFocusChangeMemberName);
 }
 
-// Per-instance pointer to the WKWebViewImpl's std::atomic<bool> tracking whether
-// the JS layer has reported editable DOM focus. Read on every key event; when
-// false (the default) the responder forwards keys to the host so the DAW
-// receives transport and shortcut keys instead of WKWebView swallowing them.
-static const char* editableFocusActiveMemberName = "editableFocusActiveHandle";
-
-[[maybe_unused]] static void setEditableFocusActiveHandle (id instance, std::atomic<bool>* flag)
-{
-    object_setInstanceVariable (instance, editableFocusActiveMemberName, flag);
-}
-
-[[maybe_unused]] static std::atomic<bool>* getEditableFocusActiveHandle (id instance)
-{
-    return getIvar<std::atomic<bool>*> (instance, editableFocusActiveMemberName);
-}
-
 #if JUCE_MAC
 template <class WebViewClass>
 struct WebViewKeyEquivalentResponder final : public ObjCClass<WebViewClass>
@@ -202,55 +186,10 @@ struct WebViewKeyEquivalentResponder final : public ObjCClass<WebViewClass>
         : Base ("WebViewKeyEquivalentResponder_")
     {
         this->template addIvar<LastFocusChange*> (lastFocusChangeMemberName);
-        this->template addIvar<std::atomic<bool>*> (editableFocusActiveMemberName);
-
-        // When an editable DOM element has focus (signalled by JS via
-        // __juceSetEditableFocusActive), keys are routed to WKWebView's default
-        // handlers so character input reaches the DOM. Otherwise we forward them
-        // to the next responder so the plugin host (DAW) receives shortcuts and
-        // MIDI-typing keys. Default is "forward to host" — the OS web surface
-        // would otherwise swallow every keystroke once it became first responder.
-        //
-        // The lambdas passed to addMethod must be captureless so JUCE's
-        // toFnPtr can lower them to plain function pointers, so the
-        // editable-focus read is inlined into each method rather than living
-        // in a local helper closure.
-
-        this->addMethod (@selector (keyDown:),
-                         [] (id self, SEL selector, NSEvent* event)
-                         {
-                             auto* handle = getEditableFocusActiveHandle (self);
-
-                             if (handle != nullptr && handle->load())
-                                 Base::template sendSuperclassMessage<void> (self, selector, event);
-                             else
-                                 [[self nextResponder] keyDown:event];
-                         });
-
-        this->addMethod (@selector (keyUp:),
-                         [] (id self, SEL selector, NSEvent* event)
-                         {
-                             auto* handle = getEditableFocusActiveHandle (self);
-
-                             if (handle != nullptr && handle->load())
-                                 Base::template sendSuperclassMessage<void> (self, selector, event);
-                             else
-                                 [[self nextResponder] keyUp:event];
-                         });
 
         this->addMethod (@selector (performKeyEquivalent:),
                          [] (id self, SEL selector, NSEvent* event)
                          {
-                             // Outside of editable focus, return NO so AppKit walks
-                             // the responder chain past us — that lets host Cmd-shortcuts
-                             // (DAW save, undo, transport variants) reach the plugin
-                             // host instead of being trapped by WKWebView.
-                             auto* handle = getEditableFocusActiveHandle (self);
-                             const bool editableFocusActive = handle != nullptr && handle->load();
-
-                             if (! editableFocusActive)
-                                 return (BOOL) NO;
-
                              const auto isCommandDown = [event]
                              {
                                  const auto modifierFlags = [event modifierFlags];
@@ -763,7 +702,6 @@ public:
                                                           groupName: nsEmptyString()]);
 
         setLastFocusChangeHandle (webView.get(), &lastFocusChange);
-        setEditableFocusActiveHandle (webView.get(), &editableFocusActive);
 
         webView.get().customUserAgent = juceStringToNS (userAgent);
 
@@ -871,15 +809,9 @@ public:
         jassertfalse;
     }
 
-    void setEditableFocusActive (bool active) override
-    {
-        editableFocusActive.store (active, std::memory_order_relaxed);
-    }
-
 private:
     WebBrowserComponent& browser;
     LastFocusChange lastFocusChange;
-    std::atomic<bool> editableFocusActive { false };
     ObjCObjectHandle<WebView*> webView;
     ObjCObjectHandle<id> clickListener;
 };
@@ -971,7 +903,6 @@ public:
                                                       configuration: config.get()]);
 
         setLastFocusChangeHandle (webView.get(), &lastFocusChange);
-        setEditableFocusActiveHandle (webView.get(), &editableFocusActive);
        #else
         webView.reset ([[WKWebView alloc] initWithFrame: CGRectMake (0, 0, 100.0f, 100.0f)
                                           configuration: config.get()]);
@@ -1277,11 +1208,6 @@ public:
                                           }];
     }
 
-    void setEditableFocusActive (bool active) override
-    {
-        editableFocusActive.store (active, std::memory_order_relaxed);
-    }
-
 private:
     static inline auto blankPageUrl = "about:blank";
 
@@ -1289,10 +1215,6 @@ private:
     DelegateConnector delegateConnector;
     bool allowAccessToEnclosingDirectory = false;
     LastFocusChange lastFocusChange;
-    // Default false → keyDown forwards to the host responder chain. Flipped
-    // to true by the JS layer via __juceSetEditableFocusActive when an
-    // editable DOM element gains focus, so character input reaches the DOM.
-    std::atomic<bool> editableFocusActive { false };
     ObjCObjectHandle<WKWebView*> webView;
     ObjCObjectHandle<id> webViewDelegate;
     String lastRequestedUrl, lastLoadedUrl;


### PR DESCRIPTION
## Summary

Consumers (`minimal_core`) have switched to a JS-side keyboard triage that routes host-bound keys through a custom bridge call on both platforms, so the JUCE-side `editableFocusActive` + WKWebView responder-chain forwarding patch is no longer driving anything.

Removed:
- `WebBrowserComponent::setEditableFocusActive` public API
- `Platform::setEditableFocusActive` virtual + Windows/macOS overrides
- Auto-registered `__juceSetEditableFocusActive` native function
- macOS WKWebView `keyDown:`/`keyUp:` overrides that forwarded to next responder
- `editableFocusActiveMemberName` ivar plumbing and helper accessors
- The `editableFocusActive` check inside the macOS `performKeyEquivalent:` override (the original JUCE Cmd-X/C/V/A clipboard handling stays)

Net result is reverting the macOS half of #26 (`WebView: forward keys to host responder chain by default`), the API + native-function plumbing it added in `WebBrowserComponent.{h,cpp}`, and the corresponding `mac.mm` changes. macOS now behaves like upstream JUCE for keyboard events — WKWebView dispatches to the DOM, the embedded JS does the triage, and the consumer-side bridge handles host forwarding via a synthesised NSEvent that bypasses WKWebView.

## Test plan

- [ ] Plugin in DAW (macOS): typing into preset search works; Space transport reaches the DAW via the new JS triage path; Cmd-X/C/V/A still work in DOM inputs (JUCE's original performKeyEquivalent: clipboard handling)
- [ ] Plugin in DAW (Windows): same as before (existing Windows path unaffected)
- [ ] Standalone Windows / macOS: no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)