### PR TITLE
WebView: revert background-colour patches (experimental)

### DIFF
--- a/modules/juce_gui_extra/misc/juce_WebBrowserComponent.h
+++ b/modules/juce_gui_extra/misc/juce_WebBrowserComponent.h
@@ -259,35 +259,12 @@ public:
                 return withMember (*this, &AppleWkWebView::acceptsFirstMouse, false);
             }
 
-            /** Sets the background colour that the WKWebView paints underneath all web content.
-
-                By default WKWebView's NSView paints an opaque white background until the page
-                actually renders, which causes a one-frame flash whenever the surface is shown
-                or resized into real bounds. Setting a colour here turns that off so the JUCE
-                layer beneath composites through (transparent / clear colour), or the chosen
-                colour shows in the overscroll area (macOS 12+ / iOS 15+).
-
-                This mirrors the equivalent option on WinWebView2 so cross-platform host code
-                can configure both backends from one place.
-
-                The colour must be either fully opaque or fully transparent.
-            */
-            [[nodiscard]] AppleWkWebView withBackgroundColour (const Colour& colour) const
-            {
-                // the background colour must be either fully opaque or transparent!
-                jassert (colour.isOpaque() || colour.isTransparent());
-
-                return withMember (*this, &AppleWkWebView::backgroundColour, colour);
-            }
-
             auto getAllowAccessToEnclosingDirectory() const { return allowAccessToEnclosingDirectory; }
-            auto getAcceptsFirstMouse() const                { return acceptsFirstMouse; }
-            auto getBackgroundColour() const                 { return backgroundColour; }
+            auto getAcceptsFirstMouse() const { return acceptsFirstMouse; }
 
         private:
             bool allowAccessToEnclosingDirectory = false;
             bool acceptsFirstMouse = true;
-            std::optional<Colour> backgroundColour;
         };
 
         /** Specifies options that apply to the Windows implementation when the WebView2 feature is

--- a/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
+++ b/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
@@ -990,46 +990,6 @@ public:
         if (@available (macOS 13.3, iOS 16.4, *))
             [webView.get() setInspectable: YES];
 
-        // Mirrors WinWebView2::withBackgroundColour. Stops WKWebView from
-        // flashing its default opaque background colour before the page has
-        // painted: drawsBackground = NO makes the OS surface transparent so
-        // the JUCE layer beneath composites through, and (on macOS 12+ /
-        // iOS 15+) the public setUnderPageBackgroundColor handles the
-        // overscroll bounce area. Set on `config` rather than the webview
-        // so the property is in place before the first paint. KVC on
-        // `drawsBackground` is documented private but stable since 10.14 —
-        // this is the same approach Tauri/wry uses (`wry/src/wkwebview/mod.rs`).
-        if (const auto bg = browserOptions.getAppleWkWebViewOptions().getBackgroundColour())
-        {
-            @try
-            {
-                [config.get() setValue: @(NO) forKey: @"drawsBackground"];
-            }
-            @catch (NSException* exception)
-            {
-                // KVC compliance is private API; if a future OS rejects it,
-                // fall back silently rather than crashing the host.
-                (void) exception;
-            }
-
-            if (@available (macOS 12.0, iOS 15.0, *))
-            {
-                const auto c = *bg;
-               #if JUCE_MAC
-                auto* colour = [NSColor colorWithSRGBRed: c.getFloatRed()
-                                                   green: c.getFloatGreen()
-                                                    blue: c.getFloatBlue()
-                                                   alpha: c.getFloatAlpha()];
-               #else
-                auto* colour = [UIColor colorWithRed: c.getFloatRed()
-                                               green: c.getFloatGreen()
-                                                blue: c.getFloatBlue()
-                                               alpha: c.getFloatAlpha()];
-               #endif
-                [webView.get() setUnderPageBackgroundColor: colour];
-            }
-        }
-
         setView (webView.get());
         owner.owner.addAndMakeVisible (this);
     }

--- a/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
+++ b/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
@@ -995,18 +995,15 @@ public:
         // painted: drawsBackground = NO makes the OS surface transparent so
         // the JUCE layer beneath composites through, and (on macOS 12+ /
         // iOS 15+) the public setUnderPageBackgroundColor handles the
-        // overscroll bounce area.
-        //
-        // The KVC trick must target the WKWebView itself, not the
-        // WKWebViewConfiguration — WKWebView copies config values at init
-        // time, so setValue on config after webview creation is a no-op.
-        // `drawsBackground` is undocumented but stable since macOS 10.14
-        // and is what Safari, Xcode and Tauri/wry use.
+        // overscroll bounce area. Set on `config` rather than the webview
+        // so the property is in place before the first paint. KVC on
+        // `drawsBackground` is documented private but stable since 10.14 —
+        // this is the same approach Tauri/wry uses (`wry/src/wkwebview/mod.rs`).
         if (const auto bg = browserOptions.getAppleWkWebViewOptions().getBackgroundColour())
         {
             @try
             {
-                [webView.get() setValue: @(NO) forKey: @"drawsBackground"];
+                [config.get() setValue: @(NO) forKey: @"drawsBackground"];
             }
             @catch (NSException* exception)
             {
@@ -1014,18 +1011,6 @@ public:
                 // fall back silently rather than crashing the host.
                 (void) exception;
             }
-
-           #if JUCE_MAC
-            // Belt-and-braces: also tell the underlying NSView's CALayer
-            // not to paint its own opaque background. Some WebKit builds
-            // still flash on the very first frame because the host NSView
-            // composites independently of the WKWebView's drawsBackground.
-            // Setting wantsLayer + a transparent layer background is a
-            // public-API safety net.
-            [webView.get() setWantsLayer: YES];
-            if (auto* layer = [webView.get() layer])
-                layer.backgroundColor = CGColorGetConstantColor (kCGColorClear);
-           #endif
 
             if (@available (macOS 12.0, iOS 15.0, *))
             {

--- a/modules/juce_gui_extra/native/juce_WebBrowserComponent_windows.cpp
+++ b/modules/juce_gui_extra/native/juce_WebBrowserComponent_windows.cpp
@@ -663,26 +663,6 @@ public:
 
         auto webViewOptions = Microsoft::WRL::Make<CoreWebView2EnvironmentOptions>();
 
-        // Mirror AppleWkWebView's drawsBackground = NO trick on Windows by
-        // pre-seeding the chromium renderer's default background colour via
-        // the command line. WebView2's runtime-level put_DefaultBackgroundColor
-        // is applied in setWebViewPreferences() *after* the controller is
-        // created, leaving a small window in which the renderer can paint its
-        // default opaque-white frame before our colour takes effect. Setting
-        // the chromium --default-background-color switch on the environment's
-        // additional browser arguments threads the colour through to the
-        // renderer process at launch, so the very first paint already uses it.
-        // Hex format matches chromium's content_switches parser
-        // (#AARRGGBB or AARRGGBB, both accepted).
-        const auto bgColour = options.getWinWebView2BackendOptions().getBackgroundColour();
-        const auto bgArg = String::formatted ("--default-background-color=#%02X%02X%02X%02X",
-                                              bgColour.getAlpha(),
-                                              bgColour.getRed(),
-                                              bgColour.getGreen(),
-                                              bgColour.getBlue());
-
-        webViewOptions->put_AdditionalBrowserArguments (bgArg.toWideCharPointer());
-
         const auto userDataFolder = options.getWinWebView2BackendOptions().getUserDataFolder().getFullPathName();
 
         auto hr = createWebViewEnvironmentWithOptions (nullptr,

--- a/modules/juce_gui_extra/native/juce_WebBrowserComponent_windows.cpp
+++ b/modules/juce_gui_extra/native/juce_WebBrowserComponent_windows.cpp
@@ -663,22 +663,25 @@ public:
 
         auto webViewOptions = Microsoft::WRL::Make<CoreWebView2EnvironmentOptions>();
 
-        // Apply the configured background colour via WebView2's documented
-        // WEBVIEW2_DEFAULT_BACKGROUND_COLOR environment variable. WebView2's
-        // runtime-level put_DefaultBackgroundColor (called in
-        // setWebViewPreferences) takes effect only after the controller is
-        // created, leaving a window in which the renderer can paint its
-        // default opaque-white frame. The env var is read by the WebView2
-        // runtime when it launches the renderer process, so the very first
-        // frame already uses our colour. Format is 8-digit hex AARRGGBB,
-        // no prefix.
+        // Mirror AppleWkWebView's drawsBackground = NO trick on Windows by
+        // pre-seeding the chromium renderer's default background colour via
+        // the command line. WebView2's runtime-level put_DefaultBackgroundColor
+        // is applied in setWebViewPreferences() *after* the controller is
+        // created, leaving a small window in which the renderer can paint its
+        // default opaque-white frame before our colour takes effect. Setting
+        // the chromium --default-background-color switch on the environment's
+        // additional browser arguments threads the colour through to the
+        // renderer process at launch, so the very first paint already uses it.
+        // Hex format matches chromium's content_switches parser
+        // (#AARRGGBB or AARRGGBB, both accepted).
         const auto bgColour = options.getWinWebView2BackendOptions().getBackgroundColour();
-        const auto bgEnv = String::formatted ("%02X%02X%02X%02X",
+        const auto bgArg = String::formatted ("--default-background-color=#%02X%02X%02X%02X",
                                               bgColour.getAlpha(),
                                               bgColour.getRed(),
                                               bgColour.getGreen(),
                                               bgColour.getBlue());
-        SetEnvironmentVariableW (L"WEBVIEW2_DEFAULT_BACKGROUND_COLOR", bgEnv.toWideCharPointer());
+
+        webViewOptions->put_AdditionalBrowserArguments (bgArg.toWideCharPointer());
 
         const auto userDataFolder = options.getWinWebView2BackendOptions().getUserDataFolder().getFullPathName();
 
@@ -1135,24 +1138,6 @@ private:
                                                 {
                                                     webView2ConstructionHelper.associatedWebViewNativeWindows.insert (childWindow);
                                                     AccessibilityHandler::setNativeChildForComponent (*self, childWindow);
-
-                                                    // Replace the WebView2 child HWND's class background brush
-                                                    // with the configured colour. WebView2's class defaults to a
-                                                    // white brush, which the OS paints into the HWND's initial
-                                                    // pixel buffer at creation and on some hide/show paths —
-                                                    // visible as a flash before the renderer composites its first
-                                                    // frame. WEBVIEW2_DEFAULT_BACKGROUND_COLOR handles the
-                                                    // renderer; this handles the HWND beneath it. The descendant
-                                                    // HWNDs (Chrome_WidgetWin_1, Intermediate D3D Window,
-                                                    // Chrome_RenderWidgetHostHWND) are owned by the WebView2
-                                                    // renderer process and SetClassLongPtrW returns
-                                                    // ERROR_ACCESS_DENIED for them, so we only stamp the direct
-                                                    // browser-host child we associated above.
-                                                    const auto bgColour = self->preferences.getWinWebView2BackendOptions().getBackgroundColour();
-                                                    static HBRUSH bgBrush = CreateSolidBrush (RGB (bgColour.getRed(),
-                                                                                                   bgColour.getGreen(),
-                                                                                                   bgColour.getBlue()));
-                                                    SetClassLongPtrW (childWindow, GCLP_HBRBACKGROUND, reinterpret_cast<LONG_PTR> (bgBrush));
                                                 }
                                             }
                                         }


### PR DESCRIPTION
## Summary

Reverts the four Minimal patches that customise WebView background painting on macOS/iOS and Windows. Purpose: validate whether the white-flash fixes were actually necessary, and isolate them as the cause of monitor-dependent pixelation we're now seeing in the Memory Rites player on macOS (high-DPI WKWebView content rasterising at 1x when the host window moves between displays with different ` + "`backingScaleFactor`" + `).

Reverts, newest first:
- ` + "`a8b28687d6`" + ` — WebView (Windows): suppress background flash on creation and hide/show
- ` + "`fe88d6d1b4`" + ` — WebView (Windows): pre-seed renderer background colour via CLI switch
- ` + "`5575dec8e8`" + ` — WebView (macOS/iOS): set drawsBackground on WebView, not config
- ` + "`bdddb1619c`" + ` — WebView (macOS/iOS): expose AppleWkWebView::withBackgroundColour

## Expected consequences

- **macOS/iOS:** The transparent-WKWebView trick goes away. WKWebView renders against its default opaque background again. The white/grey flash on first reveal will likely return until we ship a different fix.
- **Windows:** The renderer's default background colour falls back to chromium's white default, and the host HWND class brush goes back to the JUCE default. Startup/hide-show flashes will likely return.
- **API surface:** ` + "`AppleWkWebView::withBackgroundColour`" + ` / ` + "`getBackgroundColour`" + ` are removed by the ` + "`bdddb1619c`" + ` revert. Any caller in ` + "`minimal_core`" + ` will fail to compile until updated — there's one call site in ` + "`lib/managers/web_bridge/MKUEmbeddedWebView.cpp`" + ` that needs to be dropped in a follow-up commit alongside the submodule bump.

## Test plan

- [ ] Build Memory Rites on macOS with this branch pinned and confirm the webview is no longer pixelated on Retina displays / when dragging across monitors
- [ ] Build on Windows and confirm WebView2 startup still works (cosmetic flash expected)
- [ ] If pixelation goes away, design a non-regressing fix for the flash (likely a ` + "`viewDidChangeBackingProperties`" + ` override on the WKWebView subclass to keep ` + "`layer.contentsScale`" + ` in sync with the window's backing factor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)