### PR TITLE
WebView (macOS): sync layer contentsScale on backing change

### DIFF
--- a/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
+++ b/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
@@ -324,6 +324,38 @@ struct WebViewKeyEquivalentResponder final : public ObjCClass<WebViewClass>
                             return result;
                          });
 
+        // When the host window moves between displays of different
+        // backingScaleFactor (Retina ↔ non-Retina, or two Retina displays
+        // at different scales), the WKWebView's root CALayer doesn't
+        // always pick up the new contentsScale. AppKit auto-syncs this
+        // for views it created in layer-backed mode, but WKWebView is
+        // layer-hosting by default; once it's been promoted via
+        // setWantsLayer:YES + explicit layer.backgroundColor (the
+        // transparency hack for the first-paint white-flash fix), the
+        // outer layer's contentsScale stays pinned to whatever it was at
+        // view creation. The renderer then composites high-DPI content
+        // into a 1× backing and the result reads as pixelated on Retina.
+        //
+        // Override viewDidChangeBackingProperties so we always re-stamp
+        // the root layer's contentsScale to match the current window's
+        // backingScaleFactor. super still runs first so WKWebView's
+        // internal layer-tree handling continues to apply.
+        this->addMethod (@selector (viewDidChangeBackingProperties),
+                         [] (id self, SEL selector)
+                         {
+                             Base::template sendSuperclassMessage<void> (self, selector);
+
+                             NSWindow* window = [(NSView*) self window];
+
+                             if (window == nil)
+                                 return;
+
+                             const CGFloat scale = window.backingScaleFactor;
+
+                             if (CALayer* layer = [(NSView*) self layer])
+                                 layer.contentsScale = scale;
+                         });
+
         if (acceptsFirstMouse)
             this->addMethod (@selector (acceptsFirstMouse:), [] (id, SEL, NSEvent*) { return YES; });
 


### PR DESCRIPTION
## Summary

Fixes monitor-dependent pixelation in the macOS WKWebView when the host plugin window moves between displays of different `backingScaleFactor` (e.g. Retina ↔ non-Retina, or mixed-DPI multi-monitor setups).

## Root cause

WKWebView is layer-hosting by default — AppKit auto-syncs its CALayer's `contentsScale` to the window's `backingScaleFactor` on display moves. The first-paint white-flash fix in `5575dec8e8` promotes the view via `setWantsLayer:YES` and stamps `layer.backgroundColor = clear`. Once that happens, the root CALayer's `contentsScale` stops tracking backing-property changes — it gets pinned to whatever it was at view creation. When the window then moves to a display with a different scale, high-DPI WebKit content composites into a 1× backing and renders as pixelated.

## Fix

Override `viewDidChangeBackingProperties` on the `WebViewKeyEquivalentResponder<WKWebView>` ObjC subclass to explicitly re-stamp `self.layer.contentsScale = self.window.backingScaleFactor` whenever AppKit notifies of a backing change. `super` still runs first so WKWebView's internal layer-tree handling continues to apply — this only ensures the root layer stays in sync.

Keeps the existing white-flash fix intact; just closes the gap it opened.

## Test plan
- [ ] Build a host plugin that embeds `WebBrowserComponent` and open it on a 2× Retina display — should render sharply (regression check)
- [ ] Drag the host window between displays of different scale factors — webview should remain sharp on both
- [ ] Open the plugin on a 1× external monitor, then drag to a 2× internal display — should rasterise correctly after the move (the case that was broken)
- [ ] Build on Windows / iOS to confirm no impact (override is inside `#if JUCE_MAC` template body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)