### PR TITLE
WebView (macOS): don't promote WKWebView to layer-backed for bg colour (fixes secondary-monitor blur)

### DIFF
--- a/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
+++ b/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
@@ -1047,17 +1047,17 @@ public:
                 (void) exception;
             }
 
-           #if JUCE_MAC
-            // Belt-and-braces: also tell the underlying NSView's CALayer
-            // not to paint its own opaque background. Some WebKit builds
-            // still flash on the very first frame because the host NSView
-            // composites independently of the WKWebView's drawsBackground.
-            // Setting wantsLayer + a transparent layer background is a
-            // public-API safety net.
-            [webView.get() setWantsLayer: YES];
-            if (auto* layer = [webView.get() layer])
-                layer.backgroundColor = CGColorGetConstantColor (kCGColorClear);
-           #endif
+            // Note: we deliberately do NOT promote the WKWebView to a
+            // layer-backed view (setWantsLayer:YES) or stamp a transparent
+            // layer.backgroundColor here. That promotion pins the view's
+            // root-layer contentsScale at creation time, so moving the host
+            // window to a display with a different backingScaleFactor leaves
+            // high-DPI content composited into a stale backing and reading as
+            // blurry on the secondary monitor. Left layer-hosting (the WKWebView
+            // default, as used by CHOC/wry/Safari), WebKit keeps the backing
+            // scale in sync across display moves on its own. drawsBackground = NO
+            // plus setUnderPageBackgroundColor below is enough to kill the
+            // first-paint flash without touching the layer.
 
             if (@available (macOS 12.0, iOS 15.0, *))
             {


### PR DESCRIPTION
## Problem

Some users report the player webview rendering **blurry on a secondary monitor** (Retina ↔ non-Retina, or two displays at different scales).

Root cause: the macOS background-colour path (`AppleWkWebView::withBackgroundColour`, which we use to suppress the first-paint white flash) promoted the `WKWebView` to a layer-backed view:

```objc
[webView setWantsLayer: YES];
layer.backgroundColor = CGColorGetConstantColor (kCGColorClear);
```

That promotion **pins the view's root-layer `contentsScale` at creation time**. When the host window then moves to a display with a different `backingScaleFactor`, high-DPI content is composited into a stale backing and reads as pixelated/blurry. A plain (layer-hosting) `WKWebView` — what CHOC, wry and Safari use — lets WebKit keep the backing scale in sync across display moves automatically.

## Change

Drop the `setWantsLayer:YES` + transparent `layer.backgroundColor` block. The WKWebView stays layer-hosting (its default). First-paint flash suppression is unchanged — it relied on `drawsBackground = NO` and `setUnderPageBackgroundColor`, both kept. The under-page background now shows the chrome colour rather than a clear layer.

The `viewDidChangeBackingProperties` re-stamp (added in #32 to chase the pinning) is left in place as a harmless backing-scale safety net.

## Testing

- [ ] First-paint white flash still suppressed (no flicker on load) with the chrome background colour
- [ ] Webview sharp when the plugin window is moved between displays of differing backing scale
- [ ] Verified in plugin host on a dual-monitor Retina + non-Retina setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)