### PR TITLE
WebView (macOS): remove orphaned contentsScale override (fixes low-DPI blur)

### DIFF
--- a/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
+++ b/modules/juce_gui_extra/native/juce_WebBrowserComponent_mac.mm
@@ -324,37 +324,12 @@ struct WebViewKeyEquivalentResponder final : public ObjCClass<WebViewClass>
                             return result;
                          });
 
-        // When the host window moves between displays of different
-        // backingScaleFactor (Retina ↔ non-Retina, or two Retina displays
-        // at different scales), the WKWebView's root CALayer doesn't
-        // always pick up the new contentsScale. AppKit auto-syncs this
-        // for views it created in layer-backed mode, but WKWebView is
-        // layer-hosting by default; once it's been promoted via
-        // setWantsLayer:YES + explicit layer.backgroundColor (the
-        // transparency hack for the first-paint white-flash fix), the
-        // outer layer's contentsScale stays pinned to whatever it was at
-        // view creation. The renderer then composites high-DPI content
-        // into a 1× backing and the result reads as pixelated on Retina.
-        //
-        // Override viewDidChangeBackingProperties so we always re-stamp
-        // the root layer's contentsScale to match the current window's
-        // backingScaleFactor. super still runs first so WKWebView's
-        // internal layer-tree handling continues to apply.
-        this->addMethod (@selector (viewDidChangeBackingProperties),
-                         [] (id self, SEL selector)
-                         {
-                             Base::template sendSuperclassMessage<void> (self, selector);
-
-                             NSWindow* window = [(NSView*) self window];
-
-                             if (window == nil)
-                                 return;
-
-                             const CGFloat scale = window.backingScaleFactor;
-
-                             if (CALayer* layer = [(NSView*) self layer])
-                                 layer.contentsScale = scale;
-                         });
+        // We intentionally do NOT override viewDidChangeBackingProperties to stamp
+        // layer.contentsScale (matching JUCE master). An earlier override force-set
+        // contentsScale = backingScaleFactor; it was added to counter the since-removed
+        // setWantsLayer:YES flash hack, but on the now layer-hosting WKWebView it clamped
+        // WebKit's root-layer raster scale and left CSS-transform-scaled content blurry on
+        // low-DPI displays. Letting WebKit manage contentsScale renders sharply.
 
         if (acceptsFirstMouse)
             this->addMethod (@selector (acceptsFirstMouse:), [] (id, SEL, NSEvent*) { return YES; });


### PR DESCRIPTION
## Problem

The player webview rendered **blurry on low-DPI (non-Retina / 100%) displays** when the host scales the editor.

## Cause

We carried a fork-local override of `viewDidChangeBackingProperties` (added in #32, "sync layer contentsScale on backing change") that force-stamped:

```objc
[self layer].contentsScale = window.backingScaleFactor;
```

That override existed **only** to counter the `setWantsLayer:YES` first-paint flash hack — which was **removed in #34**. With the WKWebView back to its default *layer-hosting* mode, the override is orphaned: stamping the WebKit-owned root layer's `contentsScale` down to the backing scale clamps WebKit's raster scale and stops it from rendering content (scaled via an ancestor CSS/host transform) at full resolution → blur on 1× displays.

## Change

Remove the override entirely, matching JUCE master. WebKit manages `contentsScale` itself and renders sharply. A short comment is left in place so the override isn't reintroduced.

This is the macOS render path returning to upstream behaviour — none of the other fork customizations (keyboard forwarding, flash/background, DevTools) touch rasterisation.

## Testing

Verified the low-DPI blur clears with the override removed (reproduced locally via macOS "Open in Low Resolution", which forces `backingScaleFactor = 1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)