### PR TITLE
Added transaction id to undo manager

### DIFF
--- a/modules/juce_data_structures/undomanager/juce_UndoManager.cpp
+++ b/modules/juce_data_structures/undomanager/juce_UndoManager.cpp
@@ -224,6 +224,12 @@ void UndoManager::beginNewTransaction (const String& actionName)
 {
     newTransaction = true;
     newTransactionName = actionName;
+    ++currentTransactionID;
+}
+
+std::uint64_t UndoManager::getCurrentTransactionID() const
+{
+    return currentTransactionID;
 }
 
 void UndoManager::setCurrentTransactionName (const String& newName)

--- a/modules/juce_data_structures/undomanager/juce_UndoManager.h
+++ b/modules/juce_data_structures/undomanager/juce_UndoManager.h
@@ -254,12 +254,22 @@ public:
     /** Returns true if the caller code is in the middle of an undo or redo action. */
     bool isPerformingUndoRedo() const;
 
+    /** Returns a monotonically-increasing identifier for the current transaction.
+
+        The ID is bumped every time beginNewTransaction() is called (including the
+        implicit calls inside undo() and redo()). Capture it before a sequence of
+        perform() calls and compare later to verify they all landed in the same
+        transaction.
+    */
+    std::uint64_t getCurrentTransactionID() const;
+
 private:
     //==============================================================================
     struct ActionSet;
     OwnedArray<ActionSet> transactions, stashedFutureTransactions;
     String newTransactionName;
     int totalUnitsStored = 0, maxNumUnitsToKeep = 0, minimumTransactionsToKeep = 0, nextIndex = 0;
+    std::uint64_t currentTransactionID = 0;
     bool newTransaction = true, isInsideUndoRedoCall = false;
     ActionSet* getCurrentSet() const;
     ActionSet* getNextSet() const;


### PR DESCRIPTION
Add a way to identify transactions in the undo manager. Used to assert that two actions are part of the same transaction.

