### PR TITLE
Fix Laggy D2D user interaction

### DIFF
--- a/modules/juce_gui_basics/native/juce_Direct2DHwndContext_windows.cpp
+++ b/modules/juce_gui_basics/native/juce_Direct2DHwndContext_windows.cpp
@@ -35,27 +35,7 @@
 namespace juce
 {
 
-class WindowsScopedEvent
-{
-public:
-    explicit WindowsScopedEvent (HANDLE handleIn)
-        : handle (handleIn)
-    {
-    }
-
-    WindowsScopedEvent()
-        : WindowsScopedEvent (CreateEvent (nullptr, FALSE, FALSE, nullptr))
-    {
-    }
-
-    HANDLE getHandle() const noexcept
-    {
-        return handle.get();
-    }
-
-private:
-    std::unique_ptr<std::remove_pointer_t<HANDLE>, FunctionPointerDestructor<CloseHandle>> handle;
-};
+using WindowsScopedEvent = std::unique_ptr<std::remove_pointer_t<HANDLE>, FunctionPointerDestructor<CloseHandle>>;
 
 //==============================================================================
 class SwapChain
@@ -100,7 +80,6 @@ public:
             return hr;
         }
 
-        // Get the waitable swap chain presentation event and set the maximum frame latency
         ComSmartPtr<IDXGISwapChain2> chain2;
         if (const auto hr = chain.QueryInterface (chain2); FAILED (hr))
             return hr;
@@ -109,6 +88,7 @@ public:
             return E_FAIL;
 
         chain2->SetMaximumFrameLatency (1);
+        event.reset (chain2->GetFrameLatencyWaitableObject());
 
         createBuffer (adapter);
         return buffer != nullptr ? S_OK : E_FAIL;
@@ -176,6 +156,17 @@ public:
         return buffer;
     }
 
+    bool canPresent()
+    {
+        didWait = didWait || event == nullptr || (WaitForSingleObjectEx (event.get(), 0, true) == WAIT_OBJECT_0);
+        return didWait;
+    }
+
+    void didPresent()
+    {
+        didWait = false;
+    }
+
     static constexpr uint32 swapChainFlags = DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT;
     static constexpr uint32 presentSyncInterval = 1;
     static constexpr uint32 presentFlags = 0;
@@ -236,6 +227,8 @@ private:
     AssignableDirectX directX;
     ComSmartPtr<IDXGISwapChain1> chain;
     ComSmartPtr<ID2D1Bitmap1> buffer;
+    WindowsScopedEvent event;
+    bool didWait = false;
 };
 
 //==============================================================================
@@ -363,6 +356,7 @@ private:
 
         bool ready = Pimpl::checkPaintReady();
         ready &= swap.canPaint();
+        ready &= swap.canPresent();
         ready &= compositionTree.has_value();
 
         return ready;
@@ -494,10 +488,14 @@ public:
         const auto hr = swap.getChain()->Present1 (swap.presentSyncInterval,
                                                    swap.presentFlags,
                                                    &params);
-        jassertquiet (SUCCEEDED (hr));
-
         if (FAILED (hr))
+        {
+            jassertfalse;
             return;
+        }
+
+        if (hr == S_OK)
+            swap.didPresent();
 
         // There's nothing waiting to be displayed in the backbuffer.
         deferredRepaints.clear();


### PR DESCRIPTION
Patch provided by the JUCE team ([forum thread](https://forum.juce.com/t/direct2d-laggy-mouse-interaction-under-heavy-paint-load-on-low-end-gpus-8-0-13-develop/69161)) fixing laggy mouse interaction under heavy paint load on slow GPUs with the Direct2D renderer. Supersedes our own #40, which implemented the same idea — we prefer this version as it is the one that should eventually land in `juce/develop`.

## Problem

Since upstream `d3a1f0f1` (maximum frame latency of 1), the Direct2D HWND context paints unconditionally and lets `Present1` block when the previous frame hasn't been displayed yet. On slow GPUs (e.g. laptop iGPUs) the message thread stalls inside `Present1` on nearly every frame, so mouse clicks and drags visibly trail the cursor. OpenGL and the software renderer are unaffected.

## How the fix works

The swap chain is already created with `DXGI_SWAP_CHAIN_FLAG_FRAME_LATENCY_WAITABLE_OBJECT`. The patch re-fetches the frame-latency waitable object — a semaphore that a wait decrements and each retiring present increments — and uses it to only start painting when a present slot is actually free:

- `SwapChain::create()` stores the waitable handle (`GetFrameLatencyWaitableObject()`) in a `CloseHandle`-owning `unique_ptr`.
- `checkPaintReady()` additionally requires `swap.canPresent()`, a **zero-timeout** wait on that handle. If the previous frame hasn't retired, `startFrame()` returns null and the peer retries on the next vblank with the dirty regions (`deferredRepaints`) intact. So an overloaded GPU now drops frames instead of blocking input processing.
- A successful wait consumes one semaphore count, so it must be paired with exactly one present: `didWait` latches true until a present returns exactly `S_OK`, at which point `didPresent()` releases the slot. Abandoned paint attempts in between keep the slot owned.
- All edge paths are biased toward the safe direction: on a failed present, a non-`S_OK` success status (e.g. `DXGI_STATUS_OCCLUDED`, which may never retire), or a missing handle, the slot stays owned / the gate returns true — worst case is the previous blocking behaviour, never a lost semaphore count (which would permanently stop painting).
- `teardown()` (`swap = {}`) closes the handle and resets the accounting, so device-loss recovery starts clean with a fresh semaphore.
- Also refactors `WindowsScopedEvent` from a class wrapper to a `unique_ptr` alias (this file is its only user).

The `DXGI_PRESENT_DO_NOT_WAIT` presents in `createSnapshot()` bypass the accounting, but an unmatched present can only inflate the semaphore (momentarily skipping a wait), which is benign and self-correcting.

Verified on the affected low-end-GPU machine: mouse interaction stays responsive under heavy paint load, with the renderer dropping frames instead of stalling the message thread.

Not yet merged in `juce/develop` as of 2026-07-17.
